### PR TITLE
fix: shema-form-switch component import error

### DIFF
--- a/src/components/JSON-schema-form/components/schema-form-switch.vue
+++ b/src/components/JSON-schema-form/components/schema-form-switch.vue
@@ -6,14 +6,14 @@
 </template>
 <script lang="ts">
 import {defineComponent, PropType, computed} from 'vue'
-import {Input} from 'ant-design-vue'
+import {Switch} from 'ant-design-vue'
 import {FormItem} from "@/types/schema";
 
 export default defineComponent({
   name: 'schema-form-textarea',
   emits: ['update:value'],
   components: {
-    [Input.TextArea.name]: Input.TextArea,
+    [Switch.name]: Switch,
   },
   props: {
     formItem: { // 表单项

--- a/src/components/JSON-schema-form/schema-form.vue
+++ b/src/components/JSON-schema-form/schema-form.vue
@@ -13,7 +13,6 @@
             v-bind="{...formItem.props,...validateInfos[formItem.field]}"
         >
           <component
-              style="min-height: 40px"
               v-model:value="modelRef[formItem.field]"
               :form-item="formItem"
               :is="getComponent(formItem.type)"/>


### PR DESCRIPTION
这个组件的antd switch导入错误了，修正了一下，顺便发现form item里的样式如果增加了“min-height: 40px”会导致类似Switch的组件样式错误，暂时先删除。