### PR TITLE
解决左侧菜单折叠后只有一级菜单时菜单文字不隐藏的问题

### DIFF
--- a/src/layout/menu/menu-item.vue
+++ b/src/layout/menu/menu-item.vue
@@ -21,7 +21,7 @@
     </a-sub-menu>
     <a-menu-item v-else :key="menuInfo.name">
       <icon-font style="color: aliceblue" :type="menuInfo.meta.icon" />
-      {{menuInfo.meta.title}}
+      <span>{{menuInfo.meta.title}}</span>
     </a-menu-item>
   </template>
 </template>


### PR DESCRIPTION
修复前：
![image](https://user-images.githubusercontent.com/3262079/106571487-2ff20780-6572-11eb-8128-204b3942fde9.png)

修复后：
![image](https://user-images.githubusercontent.com/3262079/106571523-3bddc980-6572-11eb-84b8-a6412b9032c6.png)
